### PR TITLE
Feature/add ship

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,9 @@ This save file can be used to play through the new mission content:
 ## Fix Details
 {{add details}}
 
+## Testing Done
+{{describe how you tested that the fix doesn't introduce other issues}}
+
 ## Save File
 This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
 {{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}
@@ -39,3 +42,9 @@ This save file can be used to verify the bugfix. The bug will occur when using {
 
 ## Usage Examples
 {{if this feature is used in the data files, provide examples!}}
+
+## Testing Done
+{{describe how you tested the new feature}}
+
+## Performance Impact
+{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}

--- a/data/test.txt
+++ b/data/test.txt
@@ -1,0 +1,9 @@
+mission "Get Rich Quick!"
+	landing
+	repeat
+	on offer
+		ship "Ibis" "Testing"
+		ship "Albatross"
+		ship "Albatross"
+		conversation
+			`"I love free ships!"`

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -215,44 +215,6 @@ void MissionAction::Load(const DataNode &node, const string &missionName)
 				giftShips.push_back(make_pair(child.Token(1),child.Token(2)));
 			else
 				giftShips.push_back(make_pair(child.Token(1),string()));
-// if(1==2) {
-// 			std::cout << "ship hasvalue\n";
-// 			string shipName;
-// 			string modelName = child.Token(1);
-// 			const Ship *model = GameData::Ships().Get(modelName);
-
-// 	    		if(child.Size()>2 && !child.Token(2).empty())
-// 	    			shipName = child.Token(2);
-
-//             // //cerr<<child.Token(2)<<endl;
-// 	    // 		std::cout << "shipName:" << shipName << "\n";
-// 	    // 		shared_ptr<Ship> ship(new Ship(*model));
-
-//             // //giftShips.push_back(ship);
-// 	    // 		ship->SetName(shipName);
-// 	    // 		ship->GetSystem();
-// 	    // 		//ship->Attributes().Get("bunks") - ship->RequiredCrew();
-// 	    // 		ship->RequiredCrew();
-// 	    // 		ship->FinishLoading(false);
-// 	    // 		ships->RequiredCrew();
-// 	    // 		ships->SetName(shipName);
-// 	    // 		ships->SetIsSpecial();
-// 	    // 		ships->SetIsYours();
-// 	    // 		ships->SetGovernment(GameData::PlayerGovernment());
-// //			shared_ptr<Ship> ship=player.GiftShip(model,shipName,0,false);
-// 			if(ship != nullptr)
-// 			{
-// //				giftShips.push_back(ship);//shared_ptr<Ship> (new Ship(*model)));
-// 				/*giftShips.back()->Disable();
-// 				giftShips.back()->RequiredCrew();
-// 				giftShips.back()->SetName(shipName);
-// 				giftShips.back()->SetIsSpecial();
-// 				giftShips.back()->SetIsYours();
-// 				giftShips.back()->SetGovernment(GameData::PlayerGovernment());*/
-// //				std::cout << "giftShips.size()" << giftShips.size() << "\n";
-// //				std::cout << "giftShips.back()->Name()" << giftShips.back()->Name() << "\n";
-// 			}
-// }
 		}
 		else if(key == "outfit" && hasValue)
 		{
@@ -584,14 +546,6 @@ MissionAction MissionAction::Instantiate(map<string, string> &subs, const System
 		int day = it.second.first + Random::Int(it.second.second - it.second.first + 1);
 		result.events[it.first] = make_pair(day, day);
 	}
-    // 	for(const shared_ptr<Ship> &ship : giftShips)
-    // {
-    //     result.giftShips.push_back(ship);//shared_ptr<Ship>(new Ship()));
-    //     result.giftShips.back()->SetSystem(origin);
-    //     result.giftShips.back()->SetGovernment(GameData::PlayerGovernment());
-    //     result.giftShips.back()->Disable();
-
-    // }
 	result.giftShips = giftShips;
 	result.giftOutfits = giftOutfits;
 	result.requiredOutfits = requiredOutfits;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -85,7 +85,7 @@ private:
 	Conversation conversation;
 
 	std::map<const GameEvent *, std::pair<int, int>> events;
-    std::vector<std::shared_ptr<Ship>> giftShips;
+	std::vector<std::pair<std::string, std::string>> giftShips;
 	std::map<const Outfit *, int> giftOutfits;
 	std::map<const Outfit *, int> requiredOutfits;
 	int64_t payment = 0;

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -28,6 +28,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <string>
 #include <utility>
 #include <vector>
+#include <limits>
 
 class Government;
 class Outfit;
@@ -121,8 +122,9 @@ public:
 	std::map<const std::shared_ptr<Ship>, const std::string> FlightCheck() const;
 	// Add a captured ship to your fleet.
 	void AddShip(const std::shared_ptr<Ship> &ship);
-	// Buy or sell a ship.
+	// Buy a ship, receive a gifted ship, or sell a ship.
 	void BuyShip(const Ship *model, const std::string &name);
+	std::shared_ptr<Ship> GiftShip(const Ship *model, const std::string &name, bool record_depriciation);
 	void SellShip(const Ship *selected);
 	void DisownShip(const Ship *selected);
 	void ParkShip(const Ship *selected, bool isParked);
@@ -246,6 +248,9 @@ public:
 	
 	
 private:
+	// Internal implementation of BuyShip and GiftShip
+	std::shared_ptr<Ship> ReceiveShip(const Ship *model, const std::string &name,int64_t cost,bool record_depriciation);
+	
 	// Don't allow anyone else to copy this class, because pointers won't get
 	// transferred properly.
 	PlayerInfo(const PlayerInfo &) = default;
@@ -269,7 +274,11 @@ private:
 	
 	// Check that this player's current state can be saved.
 	bool CanBeSaved() const;
-	
+
+public:
+	// Special value sent to ReceiveShip to tell it to use the ship cost from
+	// the game data files:
+	static const int64_t DEFAULT_COST=std::numeric_limits<int64_t>::min();
 	
 private:
 	std::string firstName;


### PR DESCRIPTION
Re-arranged code to get the ship-gifting feature to work.   Several more changes are needed:

1. If the player is gifted many ships, only say the name of the first one.
2. If the player is gifted only a few ships, maybe put them all in one dialog.
3. Specify a phrase instead of a ship name (perhaps `ship Gull phrase:remnant`)
4. Gift several of the same ship type (`ship 13 Sparrow phrase:pirate`)
5. Allow gifting within a conversation `apply` block. This didn't work when I tried, but perhaps I did something wrong.

I moved the gifting code to Player so it should be easier to gift from other parts of the program now.
